### PR TITLE
Use includes instead of indexOf

### DIFF
--- a/src/policy.js
+++ b/src/policy.js
@@ -19,7 +19,7 @@ function shouldReplaceJsxAttribute({ path, types: t, options }) {
 
   return t.isStringLiteral(path.node.value)
             && attrs
-            && attrs.indexOf(attrName) >= 0;
+            && attrs.includes(attrName);
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 const punctuations = ['.', ',', ';', '?', '!'];
+
 function isPunctuation(value) {
-  return punctuations.indexOf(value.trim()) >= 0;
+  return punctuations.includes(value.trim());
 }
 
 module.exports = {


### PR DESCRIPTION
Use [String.includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) and [Array.includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes).